### PR TITLE
Fix OpenGraph type for Next.js build

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Strike Face Ceramic Armor Plates — Class 6",
     description: "Certified ceramic armor plates. Withstands B-32 bullets. Only 2.8kg weight.",
-    type: "product",
+    type: "website",
     locale: "en_US",
     siteName: "Strike Face Armor",
     images: [


### PR DESCRIPTION
## Summary
- fix invalid OpenGraph metadata type on the homepage

## Testing
- `pnpm lint` *(fails: prompts to configure ESLint)*
- `pnpm build` *(fails: cannot fetch Google Fonts during build)*

------
https://chatgpt.com/codex/tasks/task_e_684707b954f88331ab2453c309cd25e8